### PR TITLE
Move developer tooling to "keep"

### DIFF
--- a/data.json
+++ b/data.json
@@ -77,9 +77,9 @@
         "usb": "native addon built with gyp",
         "zlib": "runs build with node-waf",
         "bignum": "native addon built with gyp",
-        "fsevents": "used in local development to install tooling",
-        "husky": "used in local development to install tooling",
-        "git-hooks": "used in local development to install tooling",
+        "fsevents": "used in local development to install tooling, can skip for CI",
+        "husky": "used in local development to install tooling, can skip for CI",
+        "git-hooks": "used in local development to install tooling, can skip for CI",
     },
     "ignore": {
         "core-js": "funding",


### PR DESCRIPTION
Hello,

thanks for providing this helpful tool! We are using it, since we decided to shield us against supply chain attacks on our npm package dependencies. As such, we need to run npm rebuild for all packages that actually have useful scripts. That is why I am suggesting, to move the three packages used for local dependencies into "keep". Of course it does depend on the context, but in our context, we need to run the scripts.

If you want to separate between production and development, a separate category might be of interest in the data.json. On the other hand, I think that npm already does that, I expect, that `husky` should only be found in the dev dependencies of most packages (and the same is true for most of the other development tool packages).