### PR TITLE
Add a --mode flag and server-side support for not filtering the data

### DIFF
--- a/api/check.js
+++ b/api/check.js
@@ -4,12 +4,18 @@ const redis = new Redis(redisUrl);
 const data = require('../data.json');
 
 module.exports = async (req, res) => {
-    const packages = req.query.packages.split(',');
-    await redis.sadd('packages', packages);
+    const packages = req.query.packages?.split(',') ?? [];
+    let result;
+    if (packages.length === 0) {
+        result = data
+    } else {
+        await redis.sadd('packages', packages);
+        result = packages.reduce((result, pkg) => {
+            result.keep[pkg] = data.keep[pkg]
+            result.ignore[pkg] = data.ignore[pkg]
+            return result;
+        }, { keep: {}, ignore: {} })
+    }
     res.setHeader('Cache-Control', 'max-age=0, s-maxage=86400');
-    res.status(200).json(packages.reduce((result, pkg) => {
-        result.keep[pkg] = data.keep[pkg]
-        result.ignore[pkg] = data.ignore[pkg]
-        return result;
-    }, { keep: {}, ignore: {} }));
+    res.status(200).json(result);
 };

--- a/cli/package-lock.json
+++ b/cli/package-lock.json
@@ -11,7 +11,8 @@
       "dependencies": {
         "glob": "^7.1.7",
         "lodash": "^4.17.21",
-        "undici": "^4.8.1"
+        "undici": "^4.8.1",
+        "yargs-parser": "^21.0.1"
       },
       "bin": {
         "can-i-ignore-scripts": "index.js"
@@ -306,6 +307,14 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
       "dev": true
+    },
+    "node_modules/yargs-parser": {
+      "version": "21.0.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.1.tgz",
+      "integrity": "sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg==",
+      "engines": {
+        "node": ">=12"
+      }
     }
   },
   "dependencies": {
@@ -563,6 +572,11 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
       "dev": true
+    },
+    "yargs-parser": {
+      "version": "21.0.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.0.1.tgz",
+      "integrity": "sha512-9BK1jFpLzJROCI5TzwZL/TU4gqjK5xiHV/RfWLOahrjAko/e4DJkRDZQXfvqAsiZzzYhgAzbgz6lg48jcm4GLg=="
     }
   }
 }

--- a/cli/package.json
+++ b/cli/package.json
@@ -32,7 +32,8 @@
   "dependencies": {
     "glob": "^7.1.7",
     "lodash": "^4.17.21",
-    "undici": "^4.8.1"
+    "undici": "^4.8.1",
+    "yargs-parser": "^21.0.1"
   },
   "devDependencies": {
     "pre-commit": "^1.2.2"


### PR DESCRIPTION
Using `--mode share-nothing`, the whole data.json file is retrieved from the server, without sharing the list of packages from node_modules to the server. Server code has been modified to allow such usage.

Using `--mode offline`, the bundled data.json is used.

Finally, `--mode online` is the default, and sends the list of packages to the server and retrieves the filtered data.
