### PR TITLE
Exit with non-zero status when non-ignorable scripts are present

### DIFF
--- a/cli/index.js
+++ b/cli/index.js
@@ -84,7 +84,11 @@ Just use something like this: npm rebuild package1 package2`)
         console.log('█▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄▄█\n')
         console.log('If you check some packages, consider contributing your findings on github.')
 
+        // Exit with non-zero (fail) if there were packages with scripts we
+        // couldn't ignore. This lets us easily test for failure in shells.
+        process.exit( keep.length + check.length > 0 );
     }).catch(err => {
         console.error(err)
+        process.exit( 1 );
     })
 

--- a/cli/index.js
+++ b/cli/index.js
@@ -86,7 +86,7 @@ Just use something like this: npm rebuild package1 package2`)
 
         // Exit with non-zero (fail) if there were packages with scripts we
         // couldn't ignore. This lets us easily test for failure in shells.
-        process.exit( keep.length + check.length > 0 );
+        process.exit( keep.length + check.length > 0 ? 1 : 0 );
     }).catch(err => {
         console.error(err)
         process.exit( 1 );


### PR DESCRIPTION
Exit with non-zero status when non-ignorable scripts are present. This allows easy failure detection in shell contexts:

```sh
npx can-i-ignore-scripts && echo "🎉" || echo "💩"
```

Specifically, this helps me incorporate this package in a GitHub Action to prevent projects from adding dependencies with pre- / post-install scripts.

Thanks for this project!