### PR TITLE
Add new entries to data.json for dependencies

### DIFF
--- a/data.json
+++ b/data.json
@@ -100,6 +100,7 @@
         "webpack-cli": "funding",
         "protobufjs": "verifies initial installation",
         "spawn-sync": "installs native modules for old node.js versions",
+        "ljharb-monorepo-symlink-test": "false detection from test files",
         "monorepo-symlink-test": "false positive",
         "uglifyjs-webpack-plugin": "just update to new versions",
         "@fortawesome/fontawesome-common-types": "prints attribution",
@@ -130,6 +131,7 @@
         "@lavamoat/preinstall-always-fail": "exists to check if it's been ignored",
         "good_dep": "false detection from test files",
         "evil_dep": "false detection from test files",
+        "es5-ext": "Broadcasts 'Call for peace' message when package is installed in Russia, otherwise no-op",
         "esbuild": "points the CLI command directly at the native executable for slightly faster build startup"
     },
     "todo": {


### PR DESCRIPTION
I started testing `ignore-scripts` as part of a security audit on a legacy Gatsby site, I struggled a bit trying to determine which packages should I allow to run post-install scripts and which not, so I created a [discussion post on Gatsby's GitHub page](https://github.com/gatsbyjs/gatsby/discussions/39579), and made a [little repo](https://github.com/7Bitrot/gatsby-ignore-scripts-test) whit a minimal installation for testing. 

While investigating about production safe way to implement `ignore-scripts` I found your tool and it was a lot of help, thank you for that!. 

So I decided to add a couple of packages to the ignore list in case some else has to deal with same dilemma:

Specifically  `ljharb-monorepo-symlink-test` and `es5-ext`, that where easy to classify on the ignore list, additionally y saw that you have `gatsby`, and `gatsby-cli` on the "todo" list which I suspect can be ignored but I'll leave those alone until I'm positive. 

Also I ran into a small issue while using your tool, while running `npx can-i-ignore-scripts` after install command suggested to add the allowed found packages to the lavamoat list: 

```cli
You have 4 packages identified as 'keep' that are not yet allowed.
  lmdb,
  @parcel/watcher,
  msgpackr-extract,
  sharp
```
I accepted the suggestion and got this change on my `package.json`

```diff
{
  "allowScripts": {
        "@lavamoat/preinstall-always-fail#3.0.0": false,
        "gatsby#5.16.1": false,
        "gatsby-plugin-sharp>sharp#0.32.6": false,
        "gatsby>@parcel/cache>lmdb#2.5.2": false,
        "gatsby>@pmmmwh/react-refresh-webpack-plugin>core-js-pure#3.24.1": false,
        "gatsby>core-js#3.48.0": false,
        "gatsby>gatsby-cli#5.16.0": false,
        "gatsby>lmdb#2.5.3": false,
        "gatsby>lmdb>msgpackr>msgpackr-extract#3.0.3": false,
        "gatsby>memoizee>es5-ext#0.10.64": false,
        "sass>@parcel/watcher#2.5.6": false,
+       "lmdb": true,
+       "@parcel/watcher": true,
+       "msgpackr-extract": true,
+       "sharp": true
      }
}
```

But after running `allow-scripts` the build failed, I think is because in lavamoad pinned version of packages are required, so `can-i-ignore-scripts` should (I think) do something like this instead?

```diff
{
  "allowScripts": {
        "@lavamoat/preinstall-always-fail#3.0.0": false,
        "gatsby#5.16.1": false,
+       "gatsby-plugin-sharp>sharp#0.32.6": true,
+       "gatsby>@parcel/cache>lmdb#2.5.2": true,
        "gatsby>@pmmmwh/react-refresh-webpack-plugin>core-js-pure#3.24.1": false,
        "gatsby>core-js#3.48.0": false,
        "gatsby>gatsby-cli#5.16.0": false,
+       "gatsby>lmdb#2.5.3": true,
+       "gatsby>lmdb>msgpackr>msgpackr-extract#3.0.3": true,
        "gatsby>memoizee>es5-ext#0.10.64": false,
+       "sass>@parcel/watcher#2.5.6": true,
-       "lmdb": true,
-       "@parcel/watcher": true,
-       "msgpackr-extract": true,
-       "sharp": true
      }
}
```

That way the Gatsby build command will run normally. Feel free to check the repository mentioned above for testing (ignore the README.md it was wrote before I found out about your package).

Let me know if this helps and thanks for your work on this package!