### PR TITLE
chore: restrict publish workflow to upstream repository

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,8 @@ permissions: {}
 
 jobs:
   publish:
-    # if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/')
+    # Only execute if running in the original repository AND triggered manually or via a version tag
+    if: github.repository == 'naugtur/can-i-ignore-scripts' && (github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/'))
     runs-on: ubuntu-latest
     permissions:
       contents: read        # checkout the tag


### PR DESCRIPTION
Not sure why you commented the if block [here](https://github.com/naugtur/can-i-ignore-scripts/commit/2481157357f58abef6b376228d59a3112ff4c6dd) but I think actions should not be trigger by a fork actions, more in this context when you expect a lot of contributions. 
 
This change will only execute the publish job if running in the original repository and triggered manually or via a version tag.

Maybe you just need the `github.repository == 'naugtur/can-i-ignore-scripts'` [🔗](https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#example-only-run-job-for-specific-repository) part?

Sorry if this is not needed, I'm kinda new to GitHub....